### PR TITLE
suggestion - removing unneeded env option

### DIFF
--- a/Cron/DumpFile.php
+++ b/Cron/DumpFile.php
@@ -62,7 +62,6 @@ class DumpFile
             'user' => $this->configuration->getUser(),
             'absolute_path' => $this->configuration->getAbsolutePath(),
             'php_version' => $this->configuration->getPhpVersion(),
-            'env' => $this->env,
             'mailto' => $this->configuration->getMailto(),
         ]);
     }

--- a/Resources/views/template.txt.twig
+++ b/Resources/views/template.txt.twig
@@ -4,6 +4,6 @@ MAILTO="{{ mailto }}"
 {% for cron in crons %}
 # {{  cron.name }}
 
-{{ cron.expression }} {{ user }} {{ php_version }} {{ absolute_path }} {{ cron.command }} --env={{ env }}
+{{ cron.expression }} {{ user }} {{ php_version }} {{ absolute_path }} {{ cron.command }}
 
 {% endfor %}

--- a/Tests/Functional/Command/GenerateCronFileCommandTest.php
+++ b/Tests/Functional/Command/GenerateCronFileCommandTest.php
@@ -17,7 +17,7 @@ class GenerateCronFileCommandTest extends TestCase
 
         $this->assertSame(0, $tester->execute(['env-mode' => 'staging']));
 
-        $expected = '* * * * * project_staging php7.3 path/to/staging app:test --env=staging';
+        $expected = '* * * * * project_staging php7.3 path/to/staging app:test';
 
         $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir').'/cron_test';
 
@@ -52,7 +52,7 @@ class GenerateCronFileCommandTest extends TestCase
         $this->assertStringContainsString('[OK] Dry run generated', $tester->getDisplay());
         $this->assertStringContainsString('# send email', $tester->getDisplay());
         $this->assertStringContainsString(
-            '* * * * * project_staging php7.3 path/to/staging app:test --env=staging',
+            '* * * * * project_staging php7.3 path/to/staging app:test',
             $tester->getDisplay()
         );
     }


### PR DESCRIPTION
feat suggest for #15 - SF apps at & after 4.4 does not need the `--env|-e` precision as it's read from .env files (or can be precised in the command itself if override is necessary)