### PR TITLE
Use APP_ENV variable to enable enduser to make command more flexible

### DIFF
--- a/Resources/views/template.txt.twig
+++ b/Resources/views/template.txt.twig
@@ -4,6 +4,6 @@ MAILTO="{{ mailto }}"
 {% for cron in crons %}
 # {{  cron.name }}
 
-{{ cron.expression }} {{ user }} {{ php_version }} {{ absolute_path }} {{ cron.command }} --env={{ env }}
+{{ cron.expression }} {{ user }} APP_ENV={{ env }} {{ php_version }} {{ absolute_path }} {{ cron.command }}
 
 {% endfor %}

--- a/Tests/Functional/Command/GenerateCronFileCommandTest.php
+++ b/Tests/Functional/Command/GenerateCronFileCommandTest.php
@@ -17,11 +17,12 @@ class GenerateCronFileCommandTest extends TestCase
 
         $this->assertSame(0, $tester->execute(['env-mode' => 'staging']));
 
-        $expected = '* * * * * project_staging php7.3 path/to/staging app:test --env=staging';
+        $expected = '* * * * * project_staging php7.3 path/to/staging app:test';
 
         $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir').'/cron_test';
 
-        $this->assertStringContainsString($expected, file_get_contents($cacheDir));
+        $this->assertStringContainsString($expected, $content = file_get_contents($cacheDir));
+        $this->assertStringContainsString('APP_ENV=staging', $content);
     }
 
     public function testGenerateEmptyCrons()
@@ -52,9 +53,10 @@ class GenerateCronFileCommandTest extends TestCase
         $this->assertStringContainsString('[OK] Dry run generated', $tester->getDisplay());
         $this->assertStringContainsString('# send email', $tester->getDisplay());
         $this->assertStringContainsString(
-            '* * * * * project_staging php7.3 path/to/staging app:test --env=staging',
-            $tester->getDisplay()
+            '* * * * * project_staging php7.3 path/to/staging app:test',
+            $display = $tester->getDisplay()
         );
+        $this->assertStringContainsString('APP_ENV=staging', $display);
     }
 
     public function testCheckExecutivePath()

--- a/Tests/Functional/Command/GenerateCronFileCommandTest.php
+++ b/Tests/Functional/Command/GenerateCronFileCommandTest.php
@@ -17,12 +17,11 @@ class GenerateCronFileCommandTest extends TestCase
 
         $this->assertSame(0, $tester->execute(['env-mode' => 'staging']));
 
-        $expected = '* * * * * project_staging php7.3 path/to/staging app:test';
+        $expected = '* * * * * project_staging APP_ENV=staging php7.3 path/to/staging app:test';
 
         $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir').'/cron_test';
 
-        $this->assertStringContainsString($expected, $content = file_get_contents($cacheDir));
-        $this->assertStringContainsString('APP_ENV=staging', $content);
+        $this->assertStringContainsString($expected, file_get_contents($cacheDir));
     }
 
     public function testGenerateEmptyCrons()
@@ -53,10 +52,9 @@ class GenerateCronFileCommandTest extends TestCase
         $this->assertStringContainsString('[OK] Dry run generated', $tester->getDisplay());
         $this->assertStringContainsString('# send email', $tester->getDisplay());
         $this->assertStringContainsString(
-            '* * * * * project_staging php7.3 path/to/staging app:test',
-            $display = $tester->getDisplay()
+            '* * * * * project_staging APP_ENV=staging php7.3 path/to/staging app:test',
+            $tester->getDisplay()
         );
-        $this->assertStringContainsString('APP_ENV=staging', $display);
     }
 
     public function testCheckExecutivePath()


### PR DESCRIPTION
If we want to redirect the command output to a file or something, the only way to do it is to override the template.

The usage of APP_ENV variable will allow to customize the `command` option for each job: `app:custom-command > /dev/null` for example.